### PR TITLE
Add DEDL load_stac executor image - dedl-executor

### DIFF
--- a/.github/workflows/build-dedl-executor.yaml
+++ b/.github/workflows/build-dedl-executor.yaml
@@ -1,0 +1,69 @@
+name: Build and publish DEDL executor image
+
+on:
+  push:
+    branches:
+      - main
+      - dedl-executor
+    paths:
+      - 'Dockerfile.executor-dedl'
+      - 'openeo_argoworkflows/executor/openeo_argoworkflows_executor/executor.py'
+      - '.github/workflows/build-dedl-executor.yaml'
+  workflow_dispatch:
+    inputs:
+      base_executor_image:
+        description: Base executor image to extend
+        required: true
+        default: ghcr.io/eodcgmbh/openeo-argoworkflows:executor-2026.5.8
+      dedl_package_ref:
+        description: Git ref for openeo-processes-dedl-cube-load
+        required: true
+        default: main
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/openeo-argoworkflows-executor-dedl
+  BASE_EXECUTOR_IMAGE: ${{ inputs.base_executor_image || 'ghcr.io/eodcgmbh/openeo-argoworkflows:executor-2026.5.8' }}
+  DEDL_PACKAGE_REF: ${{ inputs.dedl_package_ref || 'main' }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,prefix=
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=2026.6.1,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.executor-dedl
+          push: true
+          build-args: |
+            BASE_EXECUTOR_IMAGE=${{ env.BASE_EXECUTOR_IMAGE }}
+            DEDL_PACKAGE_REF=${{ env.DEDL_PACKAGE_REF }}
+          secrets: |
+            eumetsat_gitlab_token=${{ secrets.EUMETSAT_GITLAB_TOKEN }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile.executor-dedl
+++ b/Dockerfile.executor-dedl
@@ -1,0 +1,34 @@
+# syntax=docker/dockerfile:1.7
+
+ARG BASE_EXECUTOR_IMAGE=ghcr.io/eodcgmbh/openeo-argoworkflows:executor-2026.5.8
+
+FROM ${BASE_EXECUTOR_IMAGE}
+
+USER root
+
+ARG DEDL_PACKAGE_REF=main
+ARG USER_ID=1000
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=secret,id=eumetsat_gitlab_token \
+    EUMETSAT_GITLAB_TOKEN="$(cat /run/secrets/eumetsat_gitlab_token)" \
+    && \
+    GIT_CONFIG_COUNT=3 \
+    GIT_CONFIG_KEY_0="url.https://oauth2:${EUMETSAT_GITLAB_TOKEN}@gitlab.eumetsat.int/.insteadOf" \
+    GIT_CONFIG_VALUE_0="https://gitlab.eumetsat.int/" \
+    GIT_CONFIG_KEY_1="url.https://github.com/.insteadOf" \
+    GIT_CONFIG_VALUE_1="git@github.com:" \
+    GIT_CONFIG_KEY_2="url.https://github.com/.insteadOf" \
+    GIT_CONFIG_VALUE_2="ssh://git@github.com/" \
+        /opt/openeo_argoworkflows_executor/.venv/bin/python -m pip install --no-cache-dir \
+            "openeo-processes-dedl-cube-load @ git+https://gitlab.eumetsat.int/dedl-cube/openeo-processes-dedl-cube-load.git@${DEDL_PACKAGE_REF}"
+
+COPY ./openeo_argoworkflows/executor/openeo_argoworkflows_executor/executor.py \
+    /opt/openeo_argoworkflows_executor/executor.py
+
+RUN chown ${USER_ID}:0 /opt/openeo_argoworkflows_executor/executor.py
+
+USER ${USER_ID}

--- a/openeo_argoworkflows/executor/openeo_argoworkflows_executor/executor.py
+++ b/openeo_argoworkflows/executor/openeo_argoworkflows_executor/executor.py
@@ -74,6 +74,9 @@ def execute(parsed_graph: OpenEOProcessGraph):
 
     _register_processes_from_module(process_registry, "openeo_processes_dask_slim")
     _register_processes_from_module(
+        process_registry, "openeo_processes_dedl_cube_load"
+    )
+    _register_processes_from_module(
         process_registry, "openeo_argoworkflows_executor.extra_processes"
     )
 


### PR DESCRIPTION
 ## Summary

  Adds a DEDL-enabled executor image that extends the published EODC `openeo-argoworkflows` executor image.

  The derived image installs `openeo-processes-dedl-cube-load` and its private DEFAIR dependencies at build time, then registers `openeo_processes_dedl_cube_load` in the executor process registry alongside
  `openeo_processes_dask_slim`.

  ## Notes

  - Uses `ghcr.io/eodcgmbh/openeo-argoworkflows:executor-2026.5.8` as the base executor image.
  - Publishes the derived image to GHCR as `openeo-argoworkflows-executor-dedl`.
  - Uses the GitHub Actions secret `EUMETSAT_GITLAB_TOKEN` as a BuildKit secret for private EUMETSAT GitLab dependencies.
  - Runtime DEDL/EODAG/S3 credentials are still expected to be provided by the deployment environment.

  ## Validation

  - Branch image build passes.
  - `openeo-processes-dedl-cube-load` now supports and tests Python 3.11/3.12 compatibility.