### PR TITLE
Pin DEDL executor VCS dependencies to resolved commits

### DIFF
--- a/.github/workflows/build-dedl-executor.yaml
+++ b/.github/workflows/build-dedl-executor.yaml
@@ -16,9 +16,13 @@ on:
         required: false
         default: ''
       dedl_package_ref:
-        description: Git ref for openeo-processes-dedl-cube-load
+        description: Git ref or SHA for openeo-processes-dedl-cube-load
         required: true
         default: main
+      slim_package_ref:
+        description: Git ref or SHA for Eurac openeo-processes-dask-slim
+        required: true
+        default: dev_remodel
 
 env:
   REGISTRY: ghcr.io
@@ -27,6 +31,7 @@ env:
   # build against (and tag the DEDL image with) a new base executor release.
   BASE_VERSION: '2026.7.1'
   DEDL_PACKAGE_REF: ${{ inputs.dedl_package_ref || 'main' }}
+  SLIM_PACKAGE_REF: ${{ inputs.slim_package_ref || 'dev_remodel' }}
 
 jobs:
   build-and-push:
@@ -46,6 +51,39 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Resolve openeo-processes-dedl-cube-load ref
+        id: dedl
+        env:
+          EUMETSAT_GITLAB_TOKEN: ${{ secrets.EUMETSAT_GITLAB_TOKEN }}
+        run: |
+          set -euo pipefail
+          ref="${DEDL_PACKAGE_REF}"
+          if [ "$ref" = "main" ]; then
+            ref="$(git \
+              -c url."https://oauth2:${EUMETSAT_GITLAB_TOKEN}@gitlab.eumetsat.int/".insteadOf="https://gitlab.eumetsat.int/" \
+              ls-remote https://gitlab.eumetsat.int/dedl-cube/openeo-processes-dedl-cube-load.git refs/heads/main \
+              | awk '{print $1}')"
+          fi
+          if [ -z "$ref" ]; then
+            echo "Could not resolve openeo-processes-dedl-cube-load ref" >&2
+            exit 1
+          fi
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve openeo-processes-dask-slim ref
+        id: slim
+        run: |
+          set -euo pipefail
+          ref="${SLIM_PACKAGE_REF}"
+          if [ "$ref" = "dev_remodel" ]; then
+            ref="$(git ls-remote https://github.com/Eurac-Research-Institute-for-EO/openeo-processes-dask-slim.git refs/heads/dev_remodel | awk '{print $1}')"
+          fi
+          if [ -z "$ref" ]; then
+            echo "Could not resolve openeo-processes-dask-slim ref" >&2
+            exit 1
+          fi
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -64,7 +102,8 @@ jobs:
           push: true
           build-args: |
             BASE_EXECUTOR_IMAGE=${{ inputs.base_executor_image || format('ghcr.io/eodcgmbh/openeo-argoworkflows:executor-{0}', env.BASE_VERSION) }}
-            DEDL_PACKAGE_REF=${{ env.DEDL_PACKAGE_REF }}
+            DEDL_PACKAGE_REF=${{ steps.dedl.outputs.ref }}
+            SLIM_PACKAGE_REF=${{ steps.slim.outputs.ref }}
           secrets: |
             eumetsat_gitlab_token=${{ secrets.EUMETSAT_GITLAB_TOKEN }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile.executor-dedl
+++ b/Dockerfile.executor-dedl
@@ -7,6 +7,7 @@ FROM ${BASE_EXECUTOR_IMAGE}
 USER root
 
 ARG DEDL_PACKAGE_REF=main
+ARG SLIM_PACKAGE_REF=dev_remodel
 ARG USER_ID=1000
 
 RUN apt-get update \
@@ -23,14 +24,6 @@ RUN apt-get update \
 # satisfies every declared requirement in the tree.
 RUN printf '%s\n' 'pystac<1.15' > /tmp/dedl-constraints.txt
 
-# Record the base image's own (PyPI) openeo-processes-dask-slim version so we can
-# restore it after the DEDL install below. The DEDL package git-pins a fork
-# (Eurac dev_remodel branch) that pip installs over our build because a direct
-# URL requirement always wins, regardless of version number.
-RUN /opt/openeo_argoworkflows_executor/.venv/bin/python -m pip show \
-        openeo-processes-dask-slim | awk '/^Version:/{print $2}' \
-        > /tmp/slim-version.txt
-
 RUN --mount=type=secret,id=eumetsat_gitlab_token \
     EUMETSAT_GITLAB_TOKEN="$(cat /run/secrets/eumetsat_gitlab_token)" \
     && \
@@ -45,14 +38,25 @@ RUN --mount=type=secret,id=eumetsat_gitlab_token \
             -c /tmp/dedl-constraints.txt \
             "openeo-processes-dedl-cube-load @ git+https://gitlab.eumetsat.int/dedl-cube/openeo-processes-dedl-cube-load.git@${DEDL_PACKAGE_REF}"
 
-# Pin back to our own PyPI openeo-processes-dask-slim, overriding the fork the
-# DEDL package drags in (its dev_remodel branch ships a breaking
-# DataArray->Dataset cube change that our executor's load processes don't
-# follow). The DEDL cube-load code only touches slim in a single place, so this
-# is safe. --no-deps keeps the rest of the resolved tree untouched.
+# Keep the final image on the same Eurac slim commit selected for this build.
+# DEDL declares this fork too, but installing it last makes the final package
+# state explicit and avoids silently falling back to the base image's PyPI slim.
 RUN /opt/openeo_argoworkflows_executor/.venv/bin/python -m pip install --no-cache-dir \
         --force-reinstall --no-deps \
-        "openeo-processes-dask-slim==$(cat /tmp/slim-version.txt)"
+        "openeo-processes-dask-slim[implementations] @ git+https://github.com/Eurac-Research-Institute-for-EO/openeo-processes-dask-slim.git@${SLIM_PACKAGE_REF}"
+
+RUN DEDL_DIRECT_URL="$(
+        /opt/openeo_argoworkflows_executor/.venv/bin/python -c "import importlib.metadata as md; print(md.distribution('openeo-processes-dedl-cube-load').read_text('direct_url.json') or '')"
+    )" \
+    && SLIM_DIRECT_URL="$(
+        /opt/openeo_argoworkflows_executor/.venv/bin/python -c "import importlib.metadata as md; print(md.distribution('openeo-processes-dask-slim').read_text('direct_url.json') or '')"
+    )" \
+    && echo "${DEDL_DIRECT_URL}" \
+    && echo "${SLIM_DIRECT_URL}" \
+    && echo "${DEDL_DIRECT_URL}" | grep -q "gitlab.eumetsat.int/dedl-cube/openeo-processes-dedl-cube-load" \
+    && echo "${DEDL_DIRECT_URL}" | grep -q "${DEDL_PACKAGE_REF}" \
+    && echo "${SLIM_DIRECT_URL}" | grep -q "github.com/Eurac-Research-Institute-for-EO/openeo-processes-dask-slim" \
+    && echo "${SLIM_DIRECT_URL}" | grep -q "${SLIM_PACKAGE_REF}"
 
 COPY ./openeo_argoworkflows/executor/openeo_argoworkflows_executor/executor.py \
     /opt/openeo_argoworkflows_executor/executor.py


### PR DESCRIPTION
Description

  This PR updates the DEDL executor build so the Git-based dependencies are resolved to immutable commit SHAs during the GitHub Actions workflow.

  Changes include:

  - Resolve openeo-processes-dedl-cube-load@main to a commit SHA before Docker build.
  - Resolve Eurac openeo-processes-dask-slim@dev_remodel to a commit SHA before Docker build.
  - Pass both resolved SHAs into Dockerfile.executor-dedl.
  - Remove the previous logic that restored the base image’s PyPI openeo-processes-dask-slim version.
  - Reinstall Eurac openeo-processes-dask-slim last so it is the final package in the image.
  - Verify both VCS-installed packages via direct_url.json during the Docker build.